### PR TITLE
Standard requirements.txt install procedure

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,7 +11,7 @@ couple of scripts. I needed to run two of these for this program to work:
 After python is installed (and your shell profile is updated), you should be
 able to run pip, which will install the rest of the dependencies (in a command
 prompt in Windows, or terminal in OSX):
-> python3 -m pip install dtw-python ultralytics numpy Pillow progressbar scikit-learn wxPython pytube moviepy pypubsub dill
+> python3 -m pip install -r requirements.txt
 
 If it complains that python3 isn't a command, the "Update Shell Profile" script
 didn't work properly, and you need to add python to your PATH.

--- a/ax_vid_compare.py
+++ b/ax_vid_compare.py
@@ -491,6 +491,8 @@ def get_time_slip_graph(axvid1, key_frames):
     draw = ImageDraw.Draw(time_slip_graph_image)
     line_points = [(frame, image_height - int(1 + (image_height - 2) * ((time_slip - min_time_slip) / time_slip_range))) for frame, time_slip in enumerate(time_slip_data)]
     draw.line(line_points, width=3)
+    zero_points = [(frame, 0) for frame, time_slip in enumerate(time_slip_data)]
+    draw.line(zero_points, width=1)
     np_frame = np.array(list(time_slip_graph_image.getdata())).reshape(image_height,num_vid1_frames,3).astype('float32')
     return cv2.resize(np_frame, (1920, TIME_SLIP_GRAPH_HEIGHT), interpolation=cv2.INTER_AREA)
 
@@ -535,7 +537,7 @@ def draw_time_slip_frame(out_vid_frame_queue, prev_frame_done_event, this_frame_
     elif total_time_slip > 0:
         text_x = 960 + time_delta_mag
         draw.rectangle([960, SLIP_BAR_Y, 960+time_delta_mag, SLIP_TEXT_Y], fill=bar_color, width=0)
-    draw.text((text_x,SLIP_TEXT_Y - 10), "%.3f" % (total_time_slip / 1000.0), font=draw_time_slip_frame.cached_font, fill=font_color)
+    draw.text((text_x,SLIP_TEXT_Y - 10), "%+.3f" % (-total_time_slip / 1000.0), font=draw_time_slip_frame.cached_font, fill=font_color)
     time_slip_bar_np = np.array(list(time_slip_bar_image.getdata())).reshape(TIMING_HEIGHT + SLIP_BAR_HEIGHT + SLIP_TEXT_HEIGHT,1920,3)
     time_slip_bar_np = np.uint8(time_slip_bar_np)
     # print(time_slip_bar_np.shape, np.hstack((frame1_np, frame2_np)).shape)

--- a/ax_vid_compare.py
+++ b/ax_vid_compare.py
@@ -491,8 +491,6 @@ def get_time_slip_graph(axvid1, key_frames):
     draw = ImageDraw.Draw(time_slip_graph_image)
     line_points = [(frame, image_height - int(1 + (image_height - 2) * ((time_slip - min_time_slip) / time_slip_range))) for frame, time_slip in enumerate(time_slip_data)]
     draw.line(line_points, width=3)
-    zero_points = [(frame, 0) for frame, time_slip in enumerate(time_slip_data)]
-    draw.line(zero_points, width=1)
     np_frame = np.array(list(time_slip_graph_image.getdata())).reshape(image_height,num_vid1_frames,3).astype('float32')
     return cv2.resize(np_frame, (1920, TIME_SLIP_GRAPH_HEIGHT), interpolation=cv2.INTER_AREA)
 

--- a/ax_vid_compare.py
+++ b/ax_vid_compare.py
@@ -30,12 +30,12 @@ COST_MATRIX_OVERLAY_SIZE = 300 # pixels
 #ARGUMENTS
 DATA_HZ = 30 # Frequency of cone comparison for alignment. Higher is better, but slower
 #OUTPUT CONTROL
-OUTPUT_ANNOTATED_VIDEOS = False # Output copies of the input videos, but with cones annotated
+OUTPUT_ANNOTATED_VIDEOS = True # Output copies of the input videos, but with cones annotated
 OUTPUT_TIME_SLIP_VIDEO = True # Output the side-by-side time slip video
 OUTPUT_COST_MATRICES = True # Save cost matrices (raw, w/ dtw path, w/ smoothed poly path) as images
 OUTPUT_FPS = 60 # Broken with USE_POLY_KEY_FRAME_SMOOTHING.
 #TUNABLES
-MIN_DETECTION_SCORE = 0.75 # minimum confidence level for cone detection to consider a cone
+MIN_DETECTION_SCORE = 0.5 # minimum confidence level for cone detection to consider a cone
 TARGET_DTW_AVERAGE_SCORE = 220 # 255 max, lower means more "gain" in cost matrix
 COST_MATRIX_RECENTER_INTERVAL = 10 # seconds, controls how frequently we estimate time slip while calculating cost matrix
 MAX_TIME_SLIP_PER_SECOND = .3 # In seconds. Increase if speed of one run is substantially different from the other. Larger value increases cost matrix creation time
@@ -43,7 +43,7 @@ USE_POLY_KEY_FRAME_SMOOTHING = True # Use polynomial smoothing when traversing p
 KEY_FRAME_COST_THRESHOLD = 230 # 255 max, higher means fewer but more confident key frames
 MIN_KEY_FRAME_DELTA = 1.0 # seconds
 MAX_KEY_FRAME_DELTA = 6.0 # seconds
-TARGET_CONES_PER_FRAME = 3 # number of cones. Higher will take longer to generate cost matrix, but it will be more accurate. Will not affect cone detection
+TARGET_CONES_PER_FRAME = 8 # number of cones. Higher will take longer to generate cost matrix, but it will be more accurate. Will not affect cone detection
 #DEBUGGING
 OVERLAY_COST_MATRIX_VISUALIZATION = False # Overlay the current snippet of the cost matrix in the output video
 LOAD_CACHED_COST_MATRIX = False # load from file rather than recomputing
@@ -531,10 +531,10 @@ def draw_time_slip_frame(out_vid_frame_queue, prev_frame_done_event, this_frame_
     text_x = 960
     if total_time_slip < 0:
         text_x = 960 - time_delta_mag
-        draw.rectangle([960-time_delta_mag, SLIP_BAR_Y, 960, SLIP_TEXT_Y], fill=bar_color, width=0)
+        draw.rectangle([960, SLIP_BAR_Y, 960+time_delta_mag, SLIP_TEXT_Y], fill=bar_color, width=0)
     elif total_time_slip > 0:
         text_x = 960 + time_delta_mag
-        draw.rectangle([960, SLIP_BAR_Y, 960+time_delta_mag, SLIP_TEXT_Y], fill=bar_color, width=0)
+        draw.rectangle([960-time_delta_mag, SLIP_BAR_Y, 960, SLIP_TEXT_Y], fill=bar_color, width=0)
     draw.text((text_x,SLIP_TEXT_Y - 10), "%+.3f" % (-total_time_slip / 1000.0), font=draw_time_slip_frame.cached_font, fill=font_color)
     time_slip_bar_np = np.array(list(time_slip_bar_image.getdata())).reshape(TIMING_HEIGHT + SLIP_BAR_HEIGHT + SLIP_TEXT_HEIGHT,1920,3)
     time_slip_bar_np = np.uint8(time_slip_bar_np)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+dtw-python
+ultralytics
+numpy
+Pillow
+progressbar
+scikit-learn
+wxPython
+pytube
+moviepy
+pypubsub
+dill


### PR DESCRIPTION
I put the python requirements in requirements.txt so that you can do install in the more standard python way using `pip install -r requirements.txt`. I updated the README to reflect this change.